### PR TITLE
Move testing variables into .env

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,37 @@
+# for testing authentication
+GCP_PROJECT_ID=
+DRIVE_TEST_FILE_ID=
+AC=default
+# these are the scopes set by default - take some of these out if you want to minimize access
+DEFAULT_SCOPES="https://www.googleapis.com/auth/userinfo.emailhttps://www.googleapis.com/auth/driveopenidhttps://www.googleapis.com/auth/cloud-platformhttps://www.googleapis.com/auth/sqlservice.login"
+EXTRA_SCOPES=",https://www.googleapis.com/auth/drivehttps://www.googleapis.com/auth/spreadsheets"
+
+# for unit tests
+MIN_NUM_ROOT_PDFS=20
+MIN_NUM_PDFS=400
+MIN_FOLDERS_ROOT=110
+TEST_FOLDER_NAME="math"
+TEST_FOLDER_NUM_CHILD_FILES=3
+SKIP_SINGLE_PARENT=true
+TEST_FOLDER_ID="1Zww9oCTFR7zYcUYXxd70yQr3sw6VdLG-"
+TEXT_FILE_NAME="fake.txt"
+TEXT_FILE_ID="1142Vn7W-pGl5nWLpUSkpOB82JDiz9R6p"
+TEXT_FILE_TYPE="text/plain"
+TEXT_FILE_CONTENT="foo is not bar\n"
+BLOB_NAME="foo.txt"
+BLOB_TYPE="text/plain"
+TEST_SHEET_ID="1DlKpVVYCrCPNfRbGsz6N_K3oPTgdC9gQIKi0aNb42uI"
+TEST_SHEET_NAME="sharedLibraries"
+EMAIL="bruce@mcpher.com"
+TIMEZONE="Europe/London"
+LOCALE="en_US"
+ZIP_TYPE="application/zip"
+KIND_DRIVE="drive#file"
+OWNER_NAME="Bruce Mcpherson"
+PUBLIC_SHARE_FILE_ID="1OFJk38kW9TRrEf-B9F1gTZk2uLV-ZSpR"
+SHARED_FILE_ID="1uz4cxEDxtQzu0cBb1B4h6fsjgWy7hNFf"
+RANDOM_IMAGE="https://picsum.photos/200"
+API_URL="http://suggestqueries.google.com/complete/search?client=chrome&hl=en&q=trump"
+API_TYPE="text/javascript"
+PDF_ID="1-YBGiTRfIYcmYUMNzNJEDlEmKAbyQqz8"
+CLEAN=true

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/private
 testongas
 **/.gas-fakes/store
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "@mcpher/gas-fakes",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcpher/gas-fakes",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
+        "@mcpher/unit": "^1.1.11",
         "@sindresorhus/is": "^7.0.1",
         "archiver": "^7.0.1",
         "get-stream": "^9.0.1",
@@ -22,6 +23,9 @@
         "sleep-synchronously": "^2.0.0",
         "to-readable-stream": "^4.0.0",
         "unzipper": "^0.12.3"
+      },
+      "engines": {
+        "node": ">=20.11.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -47,6 +51,11 @@
       "dependencies": {
         "buffer": "^6.0.3"
       }
+    },
+    "node_modules/@mcpher/unit": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@mcpher/unit/-/unit-1.1.11.tgz",
+      "integrity": "sha512-KpaFjsB9+50zMZxsAGxeT++8NrXh9tM1CBzVx23al385xQgaPxfyc4wHdbCaeqfTWXSrm06JwcQ7unHqVkq5lg=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
+  "engines": {
+    "node": ">=20.11.0"
+  },
   "dependencies": {
+    "@mcpher/unit": "^1.1.11",
     "@sindresorhus/is": "^7.0.1",
     "archiver": "^7.0.1",
     "get-stream": "^9.0.1",
@@ -17,7 +21,7 @@
   },
   "type": "module",
   "scripts": {
-    "test": "node ./test/test.js",
+    "test": "node --env-file=.env ./test/test.js",
     "pub": "npm publish --access public"
   },
   "name": "@mcpher/gas-fakes",

--- a/shells/setaccount.sh
+++ b/shells/setaccount.sh
@@ -1,15 +1,19 @@
+# load in environment variables from root folder
+ROOT_DIRECTORY=$(git rev-parse --show-toplevel)
+source "$ROOT_DIRECTORY/.env"
+
 # project ID
-P=YOUR_GCP_PROJECT_ID
+P=$GCP_PROJECT_ID
 
 # config to activate - multiple configs can each be named
 # here we're working on the default project configuration
 AC=default
 
 # these are the ones it sets by default - take some of these out if you want to minimize access
-DEFAULT_SCOPES="https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/drive,openid,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/sqlservice.login"
+DEFAULT_SCOPES=$DEFAULT_SCOPES
 
 # these are the ones we want to add (note comma at beginning)
-EXTRA_SCOPES=",https://www.googleapis.com/auth/drive,https://www.googleapis.com/auth/spreadsheets"
+EXTRA_SCOPES=$EXTRA_SCOPES
 
 SCOPES="${DEFAULT_SCOPES}${EXTRA_SCOPES}"
 

--- a/shells/testtoken.sh
+++ b/shells/testtoken.sh
@@ -1,6 +1,10 @@
+# load in environment variables from root folder
+ROOT_DIRECTORY=$(git rev-parse --show-toplevel)
+source "$ROOT_DIRECTORY/.env"
+
 # check tokens have scopes required for DRIVE access
 # set below to a fileid on drive you have access to
-FILE_ID=SOME_FILE_ID
+FILE_ID=$DRIVE_TEST_FILE_ID
 
 # get the access tokens and current project
 ADT=$(gcloud auth application-default print-access-token)

--- a/test/package.json
+++ b/test/package.json
@@ -1,11 +1,14 @@
 {
+  "engines": {
+    "node": ">=20.11.0"
+  },
   "dependencies": {
     "@mcpher/unit": "^1.1.10",
     "@mcpher/gas-fakes": "^1.0.2"
   },
   "type": "module",
   "scripts": {
-    "test": "node test.js"
+    "test": "node --env-file=../.env test.js"
   },
   "name": "test-gas-fakes",
   "version": "1.0.1",

--- a/test/test.js
+++ b/test/test.js
@@ -27,38 +27,38 @@ const testFakes = () => {
     unitExports.CodeLocator.setScriptId(ScriptApp.getScriptId())
   }
 
-  // these are som fixtures to test applicable to my own drive
+  // these are fixtures to test
+  // using process.env creates strings, convert to appropriate types as needed
   const fixes = {
-    MIN_ROOT_PDFS: 20,
-    MIN_PDFS: 400,
-    MIN_FOLDERS_ROOT: 110,
-    TEST_FOLDER_NAME: "math",
-    TEST_FOLDER_FILES: 3,
-    SKIP_SINGLE_PARENT: true,
-    TEXT_FILE_NAME: 'fake.txt',
-    TEST_FOLDER_ID: '1Zww9oCTFR7zYcUYXxd70yQr3sw6VdLG-',
-    TEXT_FILE_ID: '1142Vn7W-pGl5nWLpUSkpOB82JDiz9R6p',
-    TEXT_FILE_TYPE: 'text/plain',
-    TEXT_FILE_CONTENT: 'foo is not bar',
-    BLOB_NAME: 'foo.txt',
-    BLOB_TYPE: 'text/plain',
-    TEST_SHEET_ID: '1DlKpVVYCrCPNfRbGsz6N_K3oPTgdC9gQIKi0aNb42uI',
-    TEST_SHEET_NAME: 'sharedlibraries',
-    EMAIL: 'bruce@mcpher.com',
-    TIMEZONE: 'Europe/London',
-    LOCALE: 'en_US',
-    ZIP_TYPE: "application/zip",
-    KIND_DRIVE: "drive#file",
-    OWNER_NAME: "Bruce Mcpherson",
-    PUBLIC_SHARE_FILE_ID: "1OFJk38kW9TRrEf-B9F1gTZk2uLV-ZSpR",
-    SHARED_FILE_ID: "1uz4cxEDxtQzu0cBb1B4h6fsjgWy7hNFf",
-    RANDOM_IMAGE: "https://picsum.photos/200",
-    API_URL: "http://suggestqueries.google.com/complete/search?client=chrome&hl=en&q=trump",
-    API_TYPE: "text/javascript",
-    // we can compare files created on either side if necessary - set CLEAN to false
-    PREFIX:Drive.isFake ? "--f" : "--g",
-    PDF_ID: "1-YBGiTRfIYcmYUMNzNJEDlEmKAbyQqz8",
-    CLEAN: true
+    MIN_ROOT_PDFS: Number(process.env.MIN_NUM_ROOT_PDFS),
+    MIN_PDFS: Number(process.env.MIN_NUM_PDFS),
+    MIN_FOLDERS_ROOT: process.env.MIN_FOLDERS_ROOT,
+    TEST_FOLDER_NAME: process.env.TEST_FOLDER_NAME,
+    TEST_FOLDER_FILES: Number(process.env.TEST_FOLDER_NUM_CHILD_FILES),
+    SKIP_SINGLE_PARENT: process.env.SKIP_SINGLE_PARENT === 'true',
+    TEST_FOLDER_ID: process.env.TEST_FOLDER_ID,
+    TEXT_FILE_NAME: process.env.TEXT_FILE_NAME,
+    TEXT_FILE_ID: process.env.TEXT_FILE_ID,
+    TEXT_FILE_TYPE: process.env.TEXT_FILE_TYPE,
+    TEXT_FILE_CONTENT: process.env.TEXT_FILE_CONTENT,
+    BLOB_NAME: process.env.BLOB_NAME,
+    BLOB_TYPE: process.env.BLOB_TYPE,
+    TEST_SHEET_ID: process.env.TEST_SHEET_ID,
+    TEST_SHEET_NAME: process.env.TEST_SHEET_NAME,
+    EMAIL: process.env.EMAIL,
+    TIMEZONE: process.env.TIMEZONE,
+    LOCALE: process.env.LOCALE,
+    ZIP_TYPE: process.env.ZIP_TYPE,
+    KIND_DRIVE: process.env.KIND_DRIVE,
+    OWNER_NAME: process.env.OWNER_NAME,
+    PUBLIC_SHARE_FILE_ID: process.env.PUBLIC_SHARE_FILE_ID,
+    SHARED_FILE_ID: process.env.SHARED_FILE_ID,
+    RANDOM_IMAGE: process.env.RANDOM_IMAGE,
+    API_URL: process.env.API_URL,
+    API_TYPE: process.env.API_TYPE,
+    PREFIX: Drive.isFake ? "--f" : "--g",
+    PDF_ID: process.env.PDF_ID,
+    CLEAN: process.env.CLEAN === 'true'
   }
 
   unit.section ("root folder checks", t=> {
@@ -118,12 +118,12 @@ const testFakes = () => {
     t.true(folderPile.length > fixes.MIN_FOLDERS_ROOT)
 
     // I know i have a folder called this
-    const math = folderPile.find(f => f.getName() === fixes.TEST_FOLDER_NAME)
-    t.is(math.getName(), fixes.TEST_FOLDER_NAME)
-    const files = math.getFiles()
-    const pile = parentCheck(files, math)
+    const knownTestFolder = folderPile.find(f => f.getName() === fixes.TEST_FOLDER_NAME)
+    t.is(knownTestFolder.getName(), fixes.TEST_FOLDER_NAME)
+    const files = knownTestFolder.getFiles()
+    const pile = parentCheck(files, knownTestFolder)
 
-    // i know i have 3 files in math
+    // i know i have this number of files in the folder
     t.is(pile.length, fixes.TEST_FOLDER_FILES)
 
     if (Drive.isFake) console.log('...cumulative drive cache performance', getPerformance())


### PR DESCRIPTION
- Refactor setaccount and testtoken.sh to use .env
- Refactor test.js to use .env and update variable names for clearer reference
- Update package and package-lock with node engine (node >=20 is required for import.meta.dirname in syncit.js)
- Update package with passing in env file for running test
- Add .env template for easy set-up of .env