### PR TITLE
Implement new tests for computeDigest and other updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You don't have access to the GAS maintained cloud project, so you'll need to cre
 
 ### Testing
 
-I recommend you use the test project included in the repo to make sure all is set up correctly. It uses a Fake DriveApp service to excercise Auth etc. Just change the fixtures in .env_template in your own environments, then `npm i && npm test`. 
+I recommend you use the test project included in the repo to make sure all is set up correctly. It uses a Fake DriveApp service to excercise Auth etc. Just change the fixtures in your own environments by following the instructions in [setup-env.md](https://github.com/brucemcpherson/gas-fakes/blob/main/setup-env.MD), then `npm i && npm test`. 
 
 Note that I use a [unit tester](https://ramblings.mcpher.com/apps-script-test-runner-library-ported-to-node/) that runs in both GAS and Node, so the exact same tests will run in both environments. There are some example tests in the repo. Each test has been proved on both Node and GAS. There's also a shell (togas.sh) which will use clasp to push the test code to Apps Script.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,6 @@
       "name": "@mcpher/gas-fakes",
       "version": "1.0.8",
       "dependencies": {
-        "@mcpher/fiddler": "^1.0.1",
-        "@mcpher/unit": "^1.1.11",
         "@sindresorhus/is": "^7.0.1",
         "archiver": "^7.0.1",
         "get-stream": "^9.0.1",
@@ -52,16 +50,6 @@
       "dependencies": {
         "buffer": "^6.0.3"
       }
-    },
-    "node_modules/@mcpher/fiddler": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@mcpher/fiddler/-/fiddler-1.0.1.tgz",
-      "integrity": "sha512-sBQ2yxzbgqI0hKbtQ3+wcIZT3MK0p65FFnmioVuYoWec2ZEPEPB2LcMUuoabtBNWWC/ewj+5Fkpx0kO5P5Vreg=="
-    },
-    "node_modules/@mcpher/unit": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@mcpher/unit/-/unit-1.1.11.tgz",
-      "integrity": "sha512-KpaFjsB9+50zMZxsAGxeT++8NrXh9tM1CBzVx23al385xQgaPxfyc4wHdbCaeqfTWXSrm06JwcQ7unHqVkq5lg=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,6 @@
     "node": ">=20.11.0"
   },
   "dependencies": {
-    "@mcpher/fiddler": "^1.0.1",
-    "@mcpher/unit": "^1.1.11",
     "@sindresorhus/is": "^7.0.1",
     "archiver": "^7.0.1",
     "get-stream": "^9.0.1",

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -88,6 +88,10 @@ const settleAsBytes = (data, charset) => {
 const stringToBytes = (string, charset) => Array.from(Buffer.from(string, charset))
 const bytesToString = (data, charset) => Buffer.from(data).toString(charset)
 
+const isByteArray = (arr) => {
+  return Array.isArray(arr) && arr.every((n) => Number.isInteger(n) && n >= 0 && n <= 255);
+}
+
 /**
  * merge something like
  * sa = "a,b,f(x,y),g(a,b),h(h)"
@@ -229,6 +233,7 @@ export const Utils = {
   bytesToString,
   settleAsBytes,
   settleAsString,
+  isByteArray,
   fromJson,
   arrify,
   makeUrlParams,


### PR DESCRIPTION
- Remove mcpher dependencies in package and package.lock at root folder
- Update README with link to setup-env
- Added test of array of non-numbers for computeHmac
- Added tests for computeDigest with bytes and bad args
- Improved error detection for computeDigest and computeHmac using
  isByteArray, also a new method