### PR TITLE
Fix order of detecting errors

### DIFF
--- a/src/services/utilities/fakeutilities.js
+++ b/src/services/utilities/fakeutilities.js
@@ -164,15 +164,14 @@ class FakeUtilities {
       matchThrow();
     }
 
-    // second arg must be string or array of bytes
-    if (typeof value !== 'string' && !Utils.isByteArray(value)) {
-      throw new Error(`Cannot convert value: ${value} to array of bytes.`)
-    }
-
-
-    // if number[], cannot have charset defined
+    // if second arg is not a string, cannot have charset defined
     if (typeof value !== 'string'  && typeof charset !== 'undefined') {
       matchThrow();
+    }
+
+    // if second arg is not a string, it must be an array of bytes
+    if (typeof value !== 'string' && !Utils.isByteArray(value)) {
+      throw new Error(`Cannot convert value: ${value} to array of bytes.`)
     }
 
     // digest algorithm must be valid

--- a/test/testutilities.js
+++ b/test/testutilities.js
@@ -316,10 +316,13 @@ export const testUtilities = (pack) => {
     t.rxMatch(t.threw(bad_params_fake_digest).toString(), /The parameters \(.*\) don't match/);
 
     // bad parameters: array but not numbers
-    //TODO: not working on apps script
     const bad_bytes = Utilities.newBlob(test_inputs[0]).getBytes().map((el) => '' + el + 'bad');
-    const bad_params_bad_bytes1 = () => Utilities.computeDigest(Utilities.DigestAlgorithm.MD5, bad_bytes, Utilities.Charset.UTF_8);
+    const bad_params_bad_bytes1 = () => Utilities.computeDigest(Utilities.DigestAlgorithm.MD5, bad_bytes);
     t.rxMatch(t.threw(bad_params_bad_bytes1).toString(), /Cannot convert .*/);
+
+    // bad parameters: digest, bad byte, charset
+    const bad_params_bad_bytes2 = () => Utilities.computeDigest(Utilities.DigestAlgorithm.MD5, bad_bytes, Utilities.Charset.UTF_8);
+    t.rxMatch(t.threw(bad_params_bad_bytes2).toString(), /The parameters \(.*\) don't match/);
 
   })
 


### PR DESCRIPTION
- Detecting that the args match parameters comes first
- Then detect if the args themselves are valid

Example: if the input is DigestAlgorithm, invalidBytes, Charset, the error that will be thrown is the mismatch in signature because any byte cannot have charset. It will NOT throw the invalid bytes.