### PR TITLE
Updated gas-fakes.js

### DIFF
--- a/gas-fakes.js
+++ b/gas-fakes.js
@@ -15,16 +15,16 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 
 // sync the version with gas fakes code since they share a package.json
-import { createRequire } from 'node:module';
+import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
-const pjson = require('./package.json');
+const pjson = require("./package.json");
 const VERSION = pjson.version;
 
 // -----------------------------------------------------------------------------
 // CONSTANTS & UTILITIES
 // -----------------------------------------------------------------------------
 
-const CLI_VERSION = "0.0.7";
+const CLI_VERSION = "0.0.8";
 const MCP_VERSION = "0.0.3";
 const execAsync = promisify(exec);
 
@@ -186,7 +186,11 @@ async function executeGasScript(options) {
     args,
   } = options;
 
-  const scriptText = filename ? fs.readFileSync(filename, "utf8") : script;
+  let scriptText = filename ? fs.readFileSync(filename, "utf8") : script;
+
+  if (scriptText) {
+    scriptText = scriptText.replace(/\\\s*?\n/g, "\n");
+  }
 
   const { mainScript, gasScript } = generateExecutionScript({
     scriptText: normalizeScriptNewlines(scriptText),
@@ -487,7 +491,10 @@ async function main() {
       if (options.args) {
         try {
           args = JSON.parse(
-            options.args.replace(/\n/g, "\\n").replace(/\r/g, "\\r")
+            options.args
+              .replace(/\\\s*?\n/g, "\\n")
+              .replace(/\n/g, "\\n")
+              .replace(/\r/g, "\\r")
           );
         } catch (err) {
           console.error("Error: Invalid JSON provided to --args option.");


### PR DESCRIPTION
I updated gas-fakes.js.

Before this update, when the following command was run, an error `SyntaxError: Invalid or unexpected token` occurred. With this update, this command can work.

```bash
gas-fakes -x -a "{\"key\":\"sample value\"}" -s ' \
function sample({ key }) { \
  const ss = SpreadsheetApp.create("sample"); \
  const sheet = ss.getSheets()[0]; \
  sheet.getRange("A1").setValue(key); \
  SpreadsheetApp.flush(); \
  const url = \
    "https://docs.google.com/spreadsheets/export?exportFormat=pdf&id=" + \
    ss.getId(); \
  const bytes = UrlFetchApp.fetch(url, { \
    headers: { authorization: "Bearer " + ScriptApp.getOAuthToken() }, \
  }).getContent(); \
  ScriptApp.__behavior.trash(); \
  return JSON.stringify({ output: Utilities.base64Encode(bytes) }); \
} \
 \
return sample(args); \
'
```
