### PR TITLE
Fix gas-fakes auth failure on Windows environments

### DIFF
--- a/src/cli/setup.js
+++ b/src/cli/setup.js
@@ -302,8 +302,8 @@ export async function initializeConfiguration(options = {}) {
           existingConfig.LOG_DESTINATION
         ) > -1
           ? ["CONSOLE", "CLOUD", "BOTH", "NONE"].indexOf(
-            existingConfig.LOG_DESTINATION
-          )
+              existingConfig.LOG_DESTINATION
+            )
           : 0,
     },
     {
@@ -316,7 +316,7 @@ export async function initializeConfiguration(options = {}) {
       ],
       initial:
         ["FILE", "UPSTASH"].indexOf(existingConfig.STORE_TYPE?.toUpperCase()) >
-          -1
+        -1
           ? ["FILE", "UPSTASH"].indexOf(existingConfig.STORE_TYPE.toUpperCase())
           : 0,
     },
@@ -486,13 +486,14 @@ export async function authenticateUser() {
 
   console.log("Revoking previous credentials...");
   try {
-    execSync("gcloud auth revoke --quiet", { stdio: "ignore" });
+    execSync("gcloud auth revoke --quiet", { stdio: "ignore", shell: true });
   } catch (e) {
     /* ignore */
   }
   try {
     execSync("gcloud auth application-default revoke --quiet", {
       stdio: "ignore",
+      shell: true,
     });
   } catch (e) {
     /* ignore */
@@ -502,6 +503,7 @@ export async function authenticateUser() {
   try {
     execSync(`gcloud config configurations describe "${activeConfig}"`, {
       stdio: "ignore",
+      shell: true,
     });
     console.log(`Configuration '${activeConfig}' already exists.`);
   } catch (error) {
@@ -518,6 +520,26 @@ export async function authenticateUser() {
 
   console.log("Initiating user login...");
   runCommandSync(`gcloud auth login ${driveAccessFlag}`);
+
+  // --- Verify that the user is actually logged in ---
+  try {
+    const currentAccount = execSync("gcloud config get-value account", {
+      encoding: "utf8",
+      shell: true,
+    }).trim();
+
+    if (!currentAccount || currentAccount === "(unset)") {
+      console.error("\n[Error] Login appeared to fail or no account selected.");
+      console.error(
+        "Please try running 'gcloud auth login' manually to diagnose issues."
+      );
+      process.exit(1);
+    }
+    console.log(`Successfully logged in as: ${currentAccount}`);
+  } catch (error) {
+    console.error("\n[Error] Failed to verify logged-in account.");
+    process.exit(1);
+  }
 
   console.log("Initiating Application Default Credentials (ADC) login...");
   runCommandSync(
@@ -543,7 +565,7 @@ export async function authenticateUser() {
     );
   }
 
-  const currentProject = execSync("gcloud config get project")
+  const currentProject = execSync("gcloud config get project", { shell: true })
     .toString()
     .trim();
   console.log(
@@ -551,11 +573,12 @@ export async function authenticateUser() {
   );
 
   console.log("\nFetching token information...");
-  const userToken = execSync("gcloud auth print-access-token")
+  const userToken = execSync("gcloud auth print-access-token", { shell: true })
     .toString()
     .trim();
   const appDefaultToken = execSync(
-    "gcloud auth application-default print-access-token"
+    "gcloud auth application-default print-access-token",
+    { shell: true }
   )
     .toString()
     .trim();

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -4,7 +4,7 @@ const require = createRequire(import.meta.url);
 const pjson = require("../../package.json");
 
 export const VERSION = pjson.version;
-export const CLI_VERSION = "0.0.18"; // Kept from original logic
+export const CLI_VERSION = "0.0.19";
 export const MCP_VERSION = "0.0.7";
 
 /**
@@ -25,7 +25,8 @@ export function normalizeScriptNewlines(text) {
  */
 export function spawnCommand(command, args) {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args);
+    // shell: true is important for Windows to find .cmd/.bat files correctly
+    const child = spawn(command, args, { shell: true });
     let stdout = "";
     let stderr = "";
 
@@ -74,7 +75,9 @@ export async function checkForGcloudCli() {
  */
 export function runCommandSync(command) {
   try {
-    execSync(command, { stdio: "inherit" });
+    // shell: true is explicitly added to ensure compatibility on Windows,
+    // especially for handling interactive commands or batch files like gcloud.cmd
+    execSync(command, { stdio: "inherit", shell: true });
   } catch (error) {
     console.error(`\nError executing command: ${command}`);
     process.exit(1);


### PR DESCRIPTION
## Description

This PR resolves an issue where the authentication flow (`gas-fakes auth`) would fail silently on Windows.

**The Issue:**
On Windows, the `gcloud` CLI is executed via a batch file (`.cmd`). When running this via Node.js's `child_process.execSync` without the `shell: true` option, the interactive login process (opening the browser) fails to trigger. This results in the script skipping the login step and subsequently failing with:
`ERROR: (gcloud.auth.print-access-token) You do not currently have an active account selected.`

**The Fix:**
1.  **Enable Shell Execution:** Added `{ shell: true }` to `execSync` and `spawn` calls in `utils.js` and `setup.js`. This ensures compatibility with Windows batch files and allows the interactive authentication session to run correctly.
2.  **Add Login Verification:** Added a validation step in `authenticateUser` (in `setup.js`) to explicitly check if an account is set using `gcloud config get-value account` immediately after the login attempt. If login fails, the script now exits with a clear error message instead of proceeding to token fetching.

## Changes
*   **`src/cli/utils.js`**: Updated `runCommandSync` and `spawnCommand` to include `{ shell: true }`.
*   **`src/cli/setup.js`**:
    *   Updated `execSync` calls to include `{ shell: true }`.
    *   Added logic to verify that `gcloud auth login` successfully set an active account.
