### PR TITLE
docs(gf_agent): Add horizontal rule limitation

### DIFF
--- a/gf_agent/knowledge/08-docs-limitations.md
+++ b/gf_agent/knowledge/08-docs-limitations.md
@@ -1,0 +1,4 @@
+### Google Docs API Limitations
+
+- **Horizontal Rules**: The underlying Google Docs API does not support creating, updating, or managing `HorizontalRule` elements. Because `gas-fakes` maps local calls to the REST API, attempting to use methods like `body.appendHorizontalRule()` or `body.insertHorizontalRule()` will crash the script with a `GoogleJsonResponseException` (e.g., `Invalid requests...`).
+  - **Workaround**: If you need to visually separate content in a generated Document, use simple text-based separators like `body.appendParagraph('--------------------------------------------------')` instead.


### PR DESCRIPTION
Documents that `HorizontalRule` elements are not supported by the underlying Google Docs API and provides a text-based workaround. This prevents the `gf_agent` from attempting to use methods like `appendHorizontalRule()` which crash the script.