### PR TITLE
fix+feat: GOOGLE_WORKSPACE_SUBJECT fallback + AUTH_TYPE=user_oauth for broker/containerised deployments

### DIFF
--- a/src/support/auth.js
+++ b/src/support/auth.js
@@ -108,10 +108,12 @@ const _getTokenInfo = async (client) => {
       method: 'GET'
     });
     tokenInfo = response.data;
+  }
 
-    if (!tokenInfo.email && process.env.GOOGLE_WORKSPACE_SUBJECT) {
-      tokenInfo.email = process.env.GOOGLE_WORKSPACE_SUBJECT;
-    }
+  // Universal fallback: some token types (e.g. authorized_user ADC without openid/userinfo.email
+  // scopes) return no email in tokeninfo. GOOGLE_WORKSPACE_SUBJECT provides it explicitly.
+  if (!tokenInfo.email && process.env.GOOGLE_WORKSPACE_SUBJECT) {
+    tokenInfo.email = process.env.GOOGLE_WORKSPACE_SUBJECT;
   }
 
   return {

--- a/src/support/auth.js
+++ b/src/support/auth.js
@@ -161,11 +161,32 @@ const setAuth = async (scopes = [], mcpLoading = false) => {
   const id = _getIdentity('google');
 
   try {
+    const authType = process.env.AUTH_TYPE?.toLowerCase()
+
+    // user_oauth: caller-supplied refresh token — no ADC or service account required.
+    // Designed for OAuth broker / WIF deployments where credentials are injected at
+    // invocation time (e.g. read from Secret Manager) rather than discovered from
+    // the environment. Set GF_OAUTH_CLIENT_ID, GF_OAUTH_CLIENT_SECRET, and
+    // GF_USER_REFRESH_TOKEN, then AUTH_TYPE=user_oauth in your .env.
+    if (authType === 'user_oauth') {
+      const clientId = process.env.GF_OAUTH_CLIENT_ID
+      const clientSecret = process.env.GF_OAUTH_CLIENT_SECRET
+      const refreshToken = process.env.GF_USER_REFRESH_TOKEN
+      if (!clientId || !clientSecret || !refreshToken) {
+        throw new Error(
+          'AUTH_TYPE=user_oauth requires GF_OAUTH_CLIENT_ID, GF_OAUTH_CLIENT_SECRET, and GF_USER_REFRESH_TOKEN to be set.'
+        )
+      }
+      id.authMethod = 'user_oauth'
+      const userClient = new OAuth2Client({ clientId, clientSecret })
+      userClient.setCredentials({ refresh_token: refreshToken })
+      id.authClient = userClient
+      id.sourceClient = userClient
+    } else {
     id.auth = new GoogleAuth()
     id.projectId = await id.auth.getProjectId()
 
     const saName = process.env.GOOGLE_SERVICE_ACCOUNT_NAME
-    const authType = process.env.AUTH_TYPE?.toLowerCase()
     const useDwd = authType === 'dwd' || (authType !== 'adc' && saName)
 
     if (!useDwd) {
@@ -268,6 +289,7 @@ const setAuth = async (scopes = [], mcpLoading = false) => {
 
       id.authClient = dwdClient
     }
+    } // end else (ADC / DWD)
   } catch (error) {
     throw error
   }
@@ -300,6 +322,7 @@ const getProjectId = () => {
   const pid = _getIdentity().projectId;
   if (is.null(pid) || is.undefined(pid)) {
     if (_platform === 'ksuite') return null;
+    if (_getIdentity().authMethod === 'user_oauth') return null;
     throw new Error("Project id not set - this means that the fxInit wasnt run");
   }
   return pid;

--- a/src/support/sxauth.js
+++ b/src/support/sxauth.js
@@ -148,6 +148,11 @@ export const sxInit = async ({ manifestPath, claspPath, settingsPath, cachePath,
         token: effectiveInfo.token
       }
 
+      if (!effectiveUser.email) {
+        syncWarn(`...Warning: Could not resolve user email from OAuth token. Session.getActiveUser().getEmail() will return undefined.`);
+        syncWarn(`...To fix: add 'openid' and 'https://www.googleapis.com/auth/userinfo.email' to your appsscript.json scopes and re-run 'gas-fakes auth', or set GOOGLE_WORKSPACE_SUBJECT=your@email.com in your .env.`);
+      }
+
       identities.google = {
         activeUser,
         effectiveUser,


### PR DESCRIPTION
## Changes

### Fix: GOOGLE_WORKSPACE_SUBJECT not respected for UserRefreshClient

`Session.getActiveUser().getEmail()` silently returned `undefined` when
using `authorized_user` ADC credentials issued without `openid` /
`userinfo.email` scopes.

`GOOGLE_WORKSPACE_SUBJECT` is documented as the override for this case,
but the fallback was only applied inside the `else` branch of
`_getTokenInfo` — the branch for clients *without* a `getTokenInfo`
method. `UserRefreshClient` (returned by `GoogleAuth` for
`authorized_user` credentials) *does* have `getTokenInfo`, so the
fallback never fired, with no warning to explain why.

**Fix:** move the fallback outside both branches so it applies whenever
`tokenInfo.email` is missing, regardless of client type. Also adds an
actionable init-time warning when user email cannot be resolved, pointing
to the missing scopes or `GOOGLE_WORKSPACE_SUBJECT` as remediation.

**To reproduce before this fix:**
```bash
gcloud auth application-default login \
  --client-id-file=your-client.json \
  --scopes="https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/drive"
# (intentionally omit openid / userinfo.email)
GOOGLE_WORKSPACE_SUBJECT=user@example.com node your-test.js
# Before: Session.getActiveUser().getEmail() → undefined
# After:  Session.getActiveUser().getEmail() → "user@example.com"

Feat: AUTH_TYPE=user_oauth

New auth mode for deployments where credentials are injected at
invocation time rather than discovered from the environment — the pattern
used by OAuth brokers and agents running under Workload Identity
Federation.

Set three env vars (in .env or at runtime) — no gcloud setup required:

AUTH_TYPE=user_oauth
GF_OAUTH_CLIENT_ID=your-client-id
GF_OAUTH_CLIENT_SECRET=your-client-secret
GF_USER_REFRESH_TOKEN=your-refresh-token

gas-fakes creates an OAuth2Client directly and skips the GoogleAuth
/ getProjectId call entirely, so it works in environments with no GCP
project configured.

Reference implementation: https://github.com/curtiskrygier/appsscript-oauth-broker
(see also companion PR #N which adds the broker as examples/oauth-broker/)

Files changed

- src/support/auth.js — universal GOOGLE_WORKSPACE_SUBJECT fallback;
AUTH_TYPE=user_oauth branch in setAuth; getProjectId returns null
for user_oauth mode
- src/support/sxauth.js — init-time warning when user email cannot be
resolved