### PR TITLE
feat: add examples/oauth-broker — per-user Workspace identity for containerised agents

### DIFF
--- a/examples/oauth-broker/README.md
+++ b/examples/oauth-broker/README.md
@@ -1,0 +1,130 @@
+# OAuth Broker — WIF → User OAuth Bridge for Workspace + Apps Script
+
+A production-ready Cloud Run service that bridges Workload Identity Federation
+(WIF) container deployments to real per-user Google Workspace identity, without
+Domain-Wide Delegation.
+
+Source: [curtiskrygier/appsscript-oauth-broker](https://github.com/curtiskrygier/appsscript-oauth-broker)
+
+## The problem
+
+`scripts.run` and Workspace APIs require a **user** OAuth token. A container
+authenticated via WIF has a service account identity — it can reach GCP APIs,
+but cannot call Drive, Docs, or Apps Script on behalf of a real user. DWD
+bridges this in some environments, but is tightly restricted in enterprise
+Google Workspace orgs.
+
+## The solution
+
+```
+User (once)
+  └─→ broker /auth  ──→  Google OAuth consent
+                    ←──  refresh_token
+                    stored in Secret Manager keyed by email
+
+Agent (every invocation, no user present)
+  └─→ broker /token?email=user@domain.com
+        └─ Secret Manager.get(email) → refresh_token
+        └─ POST oauth2.googleapis.com/token → access_token
+  ←── access_token
+  └─→ scripts.run  /  Drive API  /  Docs API  (as the real user)
+```
+
+The container uses its WIF-derived service account identity to authenticate to
+the broker and to Secret Manager. The user's refresh token handles the Workspace
+execution layer. These are two separate identity concerns — WIF handles
+infrastructure, OAuth handles Workspace.
+
+## Structure
+
+```
+broker/          Cloud Run service (FastAPI)
+  main.py        /auth, /auth/callback, /token, /health routes
+  requirements.txt
+  Dockerfile
+
+agent/           Client utilities for your ADK / Reasoning Engine agent
+  auth_utils.py  get_access_token(email), scripts_run(token, fn, params)
+  requirements.txt
+
+.env.example     Configuration reference for broker, agent, and gas-fakes local testing
+```
+
+## Broker endpoints
+
+| Route | Purpose |
+|---|---|
+| `GET /auth` | Starts OAuth consent (PKCE). Send users here once. |
+| `GET /auth/callback` | Receives auth code, stores refresh token in Secret Manager. |
+| `GET /token?email=` | Returns a fresh access token for an enrolled user. Requires `Authorization: Bearer <TOKEN_SERVICE_SECRET>`. |
+| `GET /health` | Liveness check. |
+
+## Deploy
+
+**Prerequisites**
+
+- GCP project with Secret Manager API enabled
+- OAuth 2.0 Web Application client (with Cloud Run callback URI in allowed redirects)
+- Client secret stored in Secret Manager as `oauth-client-secret` (or set `CLIENT_SECRET_ID`)
+- Cloud Run service account with `roles/secretmanager.secretAccessor`
+
+```bash
+cd broker
+
+gcloud run deploy oauth-broker \
+  --source . \
+  --region europe-west1 \
+  --set-env-vars "PROJECT_ID=YOUR_PROJECT,CLIENT_ID=YOUR_CLIENT_ID,REDIRECT_URI=https://YOUR-SERVICE.run.app/auth/callback,TOKEN_SERVICE_SECRET=$(python3 -c 'import secrets; print(secrets.token_hex(32))')" \
+  --no-allow-unauthenticated
+```
+
+**Enrol a user** (one-time per user):
+
+```
+https://YOUR-SERVICE.run.app/auth
+```
+
+**Call from your agent:**
+
+```python
+from agent.auth_utils import get_access_token, scripts_run
+
+token = await get_access_token("user@yourdomain.com")
+if token is None:
+    # user hasn't completed /auth — surface the auth URL
+    return f"Please visit {AUTH_SERVICE_URL}/auth to authorise access."
+
+result = scripts_run(token, "myGasFunction", {"param": "value"})
+```
+
+## Testing locally with gas-fakes
+
+`AUTH_TYPE=user_oauth` (added in the companion PR) lets you test broker-injected
+credentials locally without deploying Cloud Run. Set the three env vars to a
+real refresh token obtained from a local broker run or `gcloud auth
+application-default login`, and gas-fakes will initialize with that user
+identity — the same path production takes.
+
+```bash
+export AUTH_TYPE=user_oauth
+export GF_OAUTH_CLIENT_ID=your-client-id
+export GF_OAUTH_CLIENT_SECRET=your-client-secret
+export GF_USER_REFRESH_TOKEN=your-refresh-token
+
+node your-test.js   # Session.getActiveUser().getEmail() returns the real user
+```
+
+See `.env.example` for a full configuration reference.
+
+## Security notes
+
+- **PKCE** prevents authorisation code interception even if the redirect URI is
+  observed in transit.
+- **HMAC-signed state** prevents CSRF on the callback.
+- **Bearer secret** on `/token` ensures only your agent can request tokens.
+- **Per-user secrets** in Secret Manager: one secret per email, named
+  `workspace-token-{email}`. The broker SA has `secretAccessor` only.
+- **Revocation**: users can revoke at `myaccount.google.com/permissions`. Clean
+  up the Secret Manager entry on `invalid_grant` (the broker handles this
+  automatically by returning `auth_required`).
+- Refresh tokens don't expire unless unused for 6 months or explicitly revoked.

--- a/examples/oauth-broker/README.md
+++ b/examples/oauth-broker/README.md
@@ -1,17 +1,16 @@
-# OAuth Broker — WIF → User OAuth Bridge for Workspace + Apps Script
+# OAuth Broker — per-user Workspace identity for containerised deployments
 
-A production-ready Cloud Run service that bridges Workload Identity Federation
-(WIF) container deployments to real per-user Google Workspace identity, without
-Domain-Wide Delegation.
+A production-ready Cloud Run service that gives containerised agents real
+per-user Google Workspace identity, without Domain-Wide Delegation.
 
 Source: [curtiskrygier/appsscript-oauth-broker](https://github.com/curtiskrygier/appsscript-oauth-broker)
 
 ## The problem
 
 `scripts.run` and Workspace APIs require a **user** OAuth token. A container
-authenticated via WIF has a service account identity — it can reach GCP APIs,
-but cannot call Drive, Docs, or Apps Script on behalf of a real user. DWD
-bridges this in some environments, but is tightly restricted in enterprise
+running as a service account identity can reach GCP APIs, but cannot call
+Drive, Docs, or Apps Script on behalf of a real user. DWD bridges this in
+some environments, but is restricted or unavailable in many enterprise
 Google Workspace orgs.
 
 ## The solution
@@ -30,10 +29,11 @@ Agent (every invocation, no user present)
   └─→ scripts.run  /  Drive API  /  Docs API  (as the real user)
 ```
 
-The container uses its WIF-derived service account identity to authenticate to
-the broker and to Secret Manager. The user's refresh token handles the Workspace
-execution layer. These are two separate identity concerns — WIF handles
-infrastructure, OAuth handles Workspace.
+The broker authenticates to Secret Manager using the container's ambient GCP
+credentials (Cloud Run service account, ADC, or Workload Identity Federation
+— the broker itself is identity-agnostic at that layer). The user's refresh
+token handles the Workspace execution layer. These are two separate identity
+concerns.
 
 ## Structure
 
@@ -99,11 +99,11 @@ result = scripts_run(token, "myGasFunction", {"param": "value"})
 
 ## Testing locally with gas-fakes
 
-`AUTH_TYPE=user_oauth` (added in the companion PR) lets you test broker-injected
-credentials locally without deploying Cloud Run. Set the three env vars to a
-real refresh token obtained from a local broker run or `gcloud auth
-application-default login`, and gas-fakes will initialize with that user
-identity — the same path production takes.
+`AUTH_TYPE=user_oauth` (added in the companion PR) lets you test
+broker-injected credentials locally without deploying Cloud Run. Set the
+three env vars to a real refresh token (from a local broker run or
+`gcloud auth application-default login`) and gas-fakes initialises with
+that user identity — the same path production takes.
 
 ```bash
 export AUTH_TYPE=user_oauth
@@ -118,13 +118,15 @@ See `.env.example` for a full configuration reference.
 
 ## Security notes
 
-- **PKCE** prevents authorisation code interception even if the redirect URI is
-  observed in transit.
+- **PKCE** prevents authorisation code interception even if the redirect URI
+  is observed in transit.
 - **HMAC-signed state** prevents CSRF on the callback.
 - **Bearer secret** on `/token` ensures only your agent can request tokens.
 - **Per-user secrets** in Secret Manager: one secret per email, named
-  `workspace-token-{email}`. The broker SA has `secretAccessor` only.
-- **Revocation**: users can revoke at `myaccount.google.com/permissions`. Clean
-  up the Secret Manager entry on `invalid_grant` (the broker handles this
-  automatically by returning `auth_required`).
-- Refresh tokens don't expire unless unused for 6 months or explicitly revoked.
+  `workspace-token-{email}`. The broker SA needs `secretAccessor` only.
+- **Revocation**: users can revoke at `myaccount.google.com/permissions`.
+  The broker returns `auth_required` on `invalid_grant`, signalling that
+  the user needs to re-enrol. Clean up the Secret Manager entry at that
+  point.
+- Refresh tokens don't expire unless unused for 6 months or explicitly
+  revoked.

--- a/examples/oauth-broker/agent/auth_utils.py
+++ b/examples/oauth-broker/agent/auth_utils.py
@@ -1,0 +1,70 @@
+import logging
+import os
+
+import httpx
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+logger = logging.getLogger(__name__)
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+# Set these as environment variables on your Reasoning Engine / Agent deployment.
+
+# URL of the deployed Cloud Run broker, no trailing slash.
+# Required: set AUTH_SERVICE_URL and TOKEN_SERVICE_SECRET in your deployment environment.
+AUTH_SERVICE_URL = os.environ.get("AUTH_SERVICE_URL", "")
+_TOKEN_SECRET = os.environ.get("TOKEN_SERVICE_SECRET", "")
+AUTH_URL = f"{AUTH_SERVICE_URL}/auth"
+
+
+# ── Token retrieval ───────────────────────────────────────────────────────────
+
+async def get_access_token(email: str) -> str | None:
+    """
+    Calls the broker's /token endpoint to get a fresh access token for the user.
+    Returns None if the user has not yet completed the /auth consent flow,
+    or if the broker is unreachable.
+    """
+    if not AUTH_SERVICE_URL or not _TOKEN_SECRET:
+        raise RuntimeError("AUTH_SERVICE_URL and TOKEN_SERVICE_SECRET environment variables must be set")
+    headers = {"Authorization": f"Bearer {_TOKEN_SECRET}"}
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{AUTH_SERVICE_URL}/token",
+                params={"email": email},
+                headers=headers,
+                timeout=10,
+            )
+            resp.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        logger.error(f"Auth service error {e.response.status_code}: {e}")
+        return None
+    except Exception as e:
+        logger.error(f"Failed to connect to auth service: {e}")
+        return None
+
+    data = resp.json()
+    if data.get("status") == "auth_required":
+        logger.warning(f"No token stored for {email} — user must visit {AUTH_URL}")
+        return None
+    return data.get("access_token")
+
+
+# ── Apps Script execution ─────────────────────────────────────────────────────
+
+def scripts_run(access_token: str, function_name: str, params: dict) -> dict:
+    """
+    Executes a function in the linked Apps Script API Executable deployment
+    using the provided user access token.
+    Requires SCRIPT_ID env var (API Executable deployment ID, starts with AKfy).
+    """
+    script_id = os.environ.get("SCRIPT_ID")
+    if not script_id:
+        raise RuntimeError("SCRIPT_ID env var is required to use scripts_run()")
+    creds = Credentials(token=access_token)
+    service = build("script", "v1", credentials=creds)
+    return service.scripts().run(
+        scriptId=script_id,
+        body={"function": function_name, "parameters": [params], "devMode": False},
+    ).execute()

--- a/examples/oauth-broker/agent/requirements.txt
+++ b/examples/oauth-broker/agent/requirements.txt
@@ -1,0 +1,3 @@
+httpx>=0.28.0
+google-api-python-client>=2.0
+google-auth>=2.0

--- a/examples/oauth-broker/broker/Dockerfile
+++ b/examples/oauth-broker/broker/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py .
+ENV PYTHONUNBUFFERED=True
+EXPOSE 8080
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/examples/oauth-broker/broker/main.py
+++ b/examples/oauth-broker/broker/main.py
@@ -1,0 +1,316 @@
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import os
+import secrets
+from email.utils import parseaddr
+from functools import lru_cache
+
+import httpx
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from google.api_core.exceptions import AlreadyExists
+from google.cloud import secretmanager
+from google_auth_oauthlib.flow import Flow
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+# All values must be provided as environment variables — no defaults.
+
+PROJECT_ID = os.environ["PROJECT_ID"]
+CLIENT_ID = os.environ["CLIENT_ID"]
+# REDIRECT_URI: full callback URL, e.g. https://YOUR-SERVICE.run.app/auth/callback
+REDIRECT_URI = os.environ["REDIRECT_URI"]
+BASE_URL = REDIRECT_URI.removesuffix("/auth/callback")
+
+# Shared secret between this service and the agent. Used to authenticate /token calls.
+# Frozen for the instance lifetime — rotation requires a redeploy (gcloud run services update --region ...).
+TOKEN_SERVICE_SECRET = os.environ["TOKEN_SERVICE_SECRET"]
+
+# CLIENT_SECRET is stored in Secret Manager under this secret ID.
+CLIENT_SECRET_ID = os.environ.get("CLIENT_SECRET_ID", "oauth-client-secret")
+
+# ── Scopes ────────────────────────────────────────────────────────────────────
+# Trim to the minimum required by your use case.
+# Mismatched scopes cause PERMISSION_DENIED from Google APIs.
+SCOPES = [
+    # Required for all deployments — identifies the user after consent
+    "openid",
+    "https://www.googleapis.com/auth/userinfo.email",
+    "https://www.googleapis.com/auth/userinfo.profile",
+
+    # Apps Script execution — minimum required for scripts.run
+    "https://www.googleapis.com/auth/script.projects",
+    "https://www.googleapis.com/auth/script.external_request",
+    "https://www.googleapis.com/auth/script.scriptapp",
+
+    # Drive / Docs / Sheets / Slides — add only what your script actually calls
+    # Remove scopes your Apps Script function does not use.
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/presentations",
+
+    # Forms — remove if your script does not create or edit Forms
+    "https://www.googleapis.com/auth/forms.body",
+
+    # Gmail — remove if your script does not send or read email
+    "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/gmail.compose",
+    "https://www.googleapis.com/auth/gmail.send",
+
+    # Calendar — remove if your script does not access Calendar
+    "https://www.googleapis.com/auth/calendar",
+
+    # Contacts / Directory — remove if your script does not look up people
+    "https://www.googleapis.com/auth/contacts",
+    "https://www.googleapis.com/auth/directory.readonly",
+]
+
+app = FastAPI(title="Cloud Run OAuth Broker")
+
+
+# ── Secret Manager helpers ────────────────────────────────────────────────────
+
+@lru_cache()
+def _get_client_secret() -> str:
+    # Cached for the instance lifetime. If the secret is rotated in Secret Manager,
+    # redeploy the service to pick up the new value (gcloud run services update --region ...).
+    from google.api_core.exceptions import NotFound
+    client = secretmanager.SecretManagerServiceClient()
+    name = f"projects/{PROJECT_ID}/secrets/{CLIENT_SECRET_ID}/versions/latest"
+    try:
+        return client.access_secret_version(request={"name": name}).payload.data.decode()
+    except NotFound:
+        raise HTTPException(status_code=500, detail=f"Broker misconfigured: secret '{CLIENT_SECRET_ID}' not found in Secret Manager")
+
+
+def _email_to_secret_id(email: str) -> str:
+    return f"workspace-token-{email.replace('@', '-at-').replace('.', '-dot-')}"
+
+
+def _get_refresh_token(email: str) -> str | None:
+    from google.api_core.exceptions import NotFound
+    secret_id = _email_to_secret_id(email)
+    try:
+        client = secretmanager.SecretManagerServiceClient()
+        name = f"projects/{PROJECT_ID}/secrets/{secret_id}/versions/latest"
+        return client.access_secret_version(request={"name": name}).payload.data.decode()
+    except NotFound:
+        return None
+    except Exception as e:
+        logger.error(f"Secret Manager error retrieving token for {email}: {e}")
+        raise HTTPException(status_code=503, detail="Token store unavailable")
+
+
+def _store_refresh_token(email: str, refresh_token: str):
+    secret_id = _email_to_secret_id(email)
+    client = secretmanager.SecretManagerServiceClient()
+    parent = f"projects/{PROJECT_ID}"
+    secret_path = f"{parent}/secrets/{secret_id}"
+    try:
+        client.get_secret(request={"name": secret_path})
+    except Exception:
+        try:
+            client.create_secret(request={
+                "parent": parent,
+                "secret_id": secret_id,
+                "secret": {"replication": {"automatic": {}}},
+            })
+        except AlreadyExists:
+            pass  # concurrent first-auth race; the other request already created the secret
+    try:
+        client.add_secret_version(request={
+            "parent": secret_path,
+            "payload": {"data": refresh_token.encode()},
+        })
+    except Exception as e:
+        logger.error(f"Failed to store refresh token for {email}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to store authorisation token")
+    logger.info(f"Stored refresh token for {email}")
+
+
+# ── OAuth flow helpers ────────────────────────────────────────────────────────
+
+def _make_flow() -> Flow:
+    return Flow.from_client_config(
+        {
+            "web": {
+                "client_id": CLIENT_ID,
+                "client_secret": _get_client_secret(),
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": "https://oauth2.googleapis.com/token",
+            }
+        },
+        scopes=SCOPES,
+    )
+
+
+def _pkce_pair() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(64)
+    challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode()).digest()
+    ).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+def _sign_state(payload: str) -> str:
+    sig = hmac.new(TOKEN_SERVICE_SECRET.encode(), payload.encode(), hashlib.sha256).hexdigest()
+    return f"{payload}.{sig}"
+
+
+def _verify_state(signed: str) -> dict:
+    if "." not in signed:
+        raise HTTPException(status_code=400, detail="Unsigned state parameter.")
+    payload, sig = signed.rsplit(".", 1)
+    expected = hmac.new(TOKEN_SERVICE_SECRET.encode(), payload.encode(), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(sig, expected):
+        raise HTTPException(status_code=400, detail="Invalid state signature.")
+    try:
+        return json.loads(base64.urlsafe_b64decode(payload.encode()).decode())
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid state parameter.")
+
+
+# ── Routes ────────────────────────────────────────────────────────────────────
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@app.get("/auth")
+async def auth_start(hint: str = ""):
+    """
+    Entry point for the OAuth consent flow.
+    Send users here once. Their refresh token is stored in Secret Manager.
+    Optional ?hint= parameter is surfaced on the success page.
+    """
+    flow = _make_flow()
+    flow.redirect_uri = REDIRECT_URI
+    verifier, challenge = _pkce_pair()
+    auth_url, oauth_state = flow.authorization_url(
+        access_type="offline",
+        prompt="consent",
+        code_challenge=challenge,
+        code_challenge_method="S256",
+    )
+    state_payload = base64.urlsafe_b64encode(
+        json.dumps({"cv": verifier, "s": oauth_state, "h": hint}).encode()
+    ).decode()
+    signed = _sign_state(state_payload)
+    auth_url = auth_url.replace(f"state={oauth_state}", f"state={signed}")
+    return RedirectResponse(auth_url)
+
+
+@app.get("/auth/callback")
+async def auth_callback(code: str, state: str):
+    import html as _html
+
+    state_data = _verify_state(state)
+    flow = _make_flow()
+    flow.redirect_uri = REDIRECT_URI
+
+    try:
+        await asyncio.to_thread(flow.fetch_token, code=code, code_verifier=state_data["cv"])
+    except Exception as e:
+        logger.error(f"Token fetch failed during OAuth callback: {e}")
+        return HTMLResponse("""<!DOCTYPE html>
+<html><head><title>Authorisation Failed</title>
+<style>body{font-family:sans-serif;max-width:600px;margin:80px auto;text-align:center;color:#202124}
+h1{color:#d93025}p{line-height:1.6}</style></head>
+<body>
+<h1>&#10007; Authorisation Failed</h1>
+<p>Something went wrong exchanging your authorisation code.</p>
+<p>This can happen if the link expired or was already used.</p>
+<p><a href="/auth">Try again</a></p>
+</body></html>""", status_code=400)
+
+    creds = flow.credentials
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                "https://www.googleapis.com/oauth2/v2/userinfo",
+                headers={"Authorization": f"Bearer {creds.token}"},
+                timeout=10,
+            )
+            resp.raise_for_status()
+        email = resp.json().get("email")
+    except Exception as e:
+        logger.error(f"Failed to retrieve user info during OAuth callback: {e}")
+        raise HTTPException(status_code=502, detail="Could not retrieve user info from Google.")
+
+    if not email:
+        raise HTTPException(status_code=400, detail="Could not retrieve user email.")
+
+    _store_refresh_token(email, creds.refresh_token)
+
+    hint = state_data.get("h", "")
+    success_message = os.environ.get("AUTH_SUCCESS_MESSAGE", "Return to your agent and re-submit your request.")
+    hint_html = (
+        f"<p>You originally asked: <em>{_html.escape(hint)}</em></p>"
+        f"<p>{_html.escape(success_message)}</p>"
+        if hint else
+        f"<p>{_html.escape(success_message)}</p>"
+    )
+    return HTMLResponse(f"""<!DOCTYPE html>
+<html><head><title>Authorisation Successful</title>
+<style>body{{font-family:sans-serif;max-width:600px;margin:80px auto;text-align:center;color:#202124}}
+h1{{color:#1a73e8}}p{{line-height:1.6}}</style></head>
+<body>
+<h1>&#10003; Authorisation Successful</h1>
+<p>Access granted for <strong>{_html.escape(email)}</strong>.</p>
+{hint_html}
+</body></html>""")
+
+
+@app.get("/token")
+async def get_token(request: Request, email: str):
+    """
+    Exchange a stored refresh token for a fresh access token.
+    Requires Authorization: Bearer <TOKEN_SERVICE_SECRET>.
+    Returns {"status": "ok", "access_token": "..."} or
+            {"status": "auth_required", "auth_url": "..."}.
+    """
+    if not hmac.compare_digest(request.headers.get("Authorization", ""), f"Bearer {TOKEN_SERVICE_SECRET}"):
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    if not email:
+        raise HTTPException(status_code=400, detail="email param required")
+
+    _, addr = parseaddr(email)
+    if "@" not in addr:
+        raise HTTPException(status_code=400, detail="Invalid email address")
+
+    refresh_token = _get_refresh_token(email)
+    if not refresh_token:
+        return JSONResponse({"status": "auth_required", "auth_url": f"{BASE_URL}/auth"})
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post("https://oauth2.googleapis.com/token", data={
+                "client_id": CLIENT_ID,
+                "client_secret": _get_client_secret(),
+                "refresh_token": refresh_token,
+                "grant_type": "refresh_token",
+            })
+        resp.raise_for_status()
+        return {"status": "ok", "access_token": resp.json()["access_token"]}
+    except httpx.HTTPStatusError as e:
+        if e.response.json().get("error") == "invalid_grant":
+            logger.warning(f"invalid_grant for {email} — token revoked or expired; re-auth required")
+            return JSONResponse({"status": "auth_required", "auth_url": f"{BASE_URL}/auth"})
+        logger.error(f"Token exchange HTTP error for {email}: {e}")
+        raise HTTPException(status_code=500, detail="Token exchange failed")
+    except Exception as e:
+        logger.error(f"Token exchange failed for {email}: {e}")
+        raise HTTPException(status_code=500, detail="Token exchange failed")
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/examples/oauth-broker/broker/requirements.txt
+++ b/examples/oauth-broker/broker/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.115.5
+uvicorn==0.32.1
+google-auth==2.48.0
+google-auth-oauthlib==1.2.1
+google-cloud-secret-manager==2.23.0
+httpx==0.28.1
+python-multipart==0.0.12


### PR DESCRIPTION
Production-ready Cloud Run OAuth broker that gives containerised agents real per-user Workspace identity without DWD. The broker stores per-user refresh tokens in Secret Manager (one-time consent via /auth) and issues fresh access tokens on demand. Works alongside the AUTH_TYPE=user_oauth mode added in #N — that mode lets you test broker-injected credentials locally against gas-fakes without deploying Cloud Run.

Source / original implementation: https://github.com/curtiskrygier/appsscript-oauth-broker — contributed here as a reference pattern for the gas-fakes multi-user / containerised use case.

WIF integration (binding the container's service account via Workload Identity Federation) is a deployment-layer concern and will be documented in a follow-up.
